### PR TITLE
Using env variables from os

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,10 @@ api:
 
 You can use environment variables in your API spec file:
 
+```bash
+export BASE_URL=https://jsonplaceholder.typicode.com/
+```
+
 ```yaml
 api:
   base_url: ${BASE_URL}
@@ -138,12 +142,7 @@ api:
           path: /1
 ```
 
-And in the config file `.scanapi.yaml` set their values:
-
-```yaml
-env_vars:
-  BASE_URL: https://jsonplaceholder.typicode.com/
-```
+**Heads up: the variable name must be in upper case.**
 
 ### Chaining Requests: Custom Vars + Python Code
 

--- a/examples/cat_api/.env-sample
+++ b/examples/cat_api/.env-sample
@@ -1,0 +1,2 @@
+export API_KEY="DEMO-API-KEY"
+export USER_ID="demo-d4332e"

--- a/examples/cat_api/.scanapi.yaml
+++ b/examples/cat_api/.scanapi.yaml
@@ -1,5 +1,2 @@
 spec_path: api.yaml
 docs_path: docs.md
-env_vars:
-  API_KEY: DEMO-API-KEY
-  USER_ID: demo-d4332e

--- a/examples/json_place_holder/.env-sample
+++ b/examples/json_place_holder/.env-sample
@@ -1,0 +1,1 @@
+export API_KEY="<INSERT YOUR API KEY HERE>"

--- a/examples/open_weather_map/.scanapi.yaml
+++ b/examples/open_weather_map/.scanapi.yaml
@@ -1,4 +1,2 @@
 spec_path: api.yaml
 docs_path: docs.md
-env_vars:
-  API_KEY: <INSERT YOUR API KEY HERE>

--- a/scanapi/errors.py
+++ b/scanapi/errors.py
@@ -18,3 +18,12 @@ class APIKeyMissingError(MalformedSpecError):
     def __init__(self, *args):
         message = "Missing api `key` at root scope in the API spec"
         super(APIKeyMissingError, self).__init__(message, *args)
+
+
+class BadConfigurationError(Exception):
+    """Raised when an environment variable was not set or was badly configured"""
+
+    def __init__(self, env_var, *args):
+        super(BadConfigurationError, self).__init__(
+            "{} environment variable not set or badly configured".format(env_var), *args
+        )

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="scanapi",
-    version="0.0.11",
+    version="0.0.12",
     author="Camila Maia",
     author_email="cmaiacd@gmail.com",
     description="Automated Testing and Documentation for your REST API",

--- a/tests/functional/step_defs/test_call_requests.py
+++ b/tests/functional/step_defs/test_call_requests.py
@@ -46,4 +46,5 @@ def get_called(api_spec, mock_request):
         headers={},
         params={},
         json={},
+        allow_redirects=False,
     )


### PR DESCRIPTION
Stop declaring the env vars on `scanapi.yaml` file and start getting these variables in fact from the os.

Closes https://github.com/camilamaia/scanapi/issues/42