### PR TITLE
Hiding sensitive info

### DIFF
--- a/scanapi/reporter.py
+++ b/scanapi/reporter.py
@@ -16,6 +16,7 @@ class Reporter:
     def write(self, responses):
         logger.info("Writing documentation")
 
+        self.hide_headers_info(responses)
         env = Environment(loader=PackageLoader("scanapi", "templates"))
         template = env.get_template(f"{self.reporter}.jinja")
         content = template.render(responses=responses)
@@ -33,3 +34,27 @@ class Reporter:
 
         logger.info("The documentation was generated successfully.")
         logger.info(f"It is available at {self.output_path}")
+
+    def hide_headers_info(self, responses):
+        hide_keys = self.hide_keys()
+
+        if not hide_keys:
+            return
+
+        [
+            self.hide_request_headers_info(response.request, hide_keys)
+            for response in responses
+        ]
+
+    def hide_request_headers_info(self, request, hide_keys):
+        request_headers = request.headers
+
+        for key in hide_keys:
+            if key in request_headers:
+                request_headers[key] = "<sensitive_information>"
+
+    def hide_keys(self):
+        if not SETTINGS.get("report") or not SETTINGS["report"].get("hide"):
+            return
+
+        return SETTINGS["report"]["hide"].get("headers")

--- a/scanapi/templates/markdown.jinja
+++ b/scanapi/templates/markdown.jinja
@@ -6,19 +6,19 @@
 
 HEADERS:
 <details><summary></summary><p>
-            
+
 ```
 {{ request.headers }}
 ```
 </p></details>
 
-### Response: {{ response.status_code }} 
+### Response: {{ response.status_code }}
 
 Is redirect? {{ response.is_redirect }}
 
 HEADERS:
 <details><summary></summary><p>
-            
+
 ```
 {{ response.headers }}
 ```
@@ -26,7 +26,7 @@ HEADERS:
 
 Content:
 <details><summary></summary><p>
-            
+
 ```
 {% if response.text %}
 {{ response.text }}

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,8 @@ test_requirements = [
     "pytest >= 5.2.4",
     "pytest-bdd >= 3.2.1",
     "pytest-cov >= 2.8.1",
-    "pytest-mock >=1.11.2",
+    "pytest-mock >= 1.11.2",
+    "requests-mock >= 1.7.0",
 ]
 
 with open("README.md", "r") as fh:

--- a/tests/unit/factories.py
+++ b/tests/unit/factories.py
@@ -1,5 +1,6 @@
 import factory
 
+from scanapi.reporter import Reporter
 from scanapi.requests_maker import RequestsMaker
 from scanapi.tree.api_node import APINode
 from scanapi.tree.api_tree import APITree
@@ -46,3 +47,12 @@ class RequestsMakerFactory(factory.Factory):
         model = RequestsMaker
 
     api_tree = factory.SubFactory(APITreeFactory)
+
+
+class ReporterFactory(factory.Factory):
+    class Meta:
+        model = Reporter
+
+    output_path = "reports/"
+    reporter = "markdown"
+    template = "templates/my_template"

--- a/tests/unit/test_reporter.py
+++ b/tests/unit/test_reporter.py
@@ -1,0 +1,120 @@
+import pytest
+import requests
+
+from scanapi.settings import SETTINGS
+from tests.unit.factories import ReporterFactory
+
+
+class TestReporter:
+    @pytest.fixture
+    def response(self, requests_mock):
+        requests_mock.request(
+            "get",
+            "http://123-fake-api.com",
+            headers={"Authorization": "abc", "Token": "123"},
+        )
+
+        return requests.request(
+            "get",
+            "http://123-fake-api.com",
+            headers={"Authorization": "abc", "Token": "123"},
+        )
+
+    @pytest.fixture
+    def req(self, response):
+        return response.request
+
+    @pytest.fixture
+    def responses(self, response):
+        return [response]
+
+    @pytest.fixture
+    def reporter(self):
+        return ReporterFactory()
+
+    class TestHideSensitiveInfo:
+        @pytest.fixture
+        def mock_hide_keys(self, mocker):
+            return mocker.patch("scanapi.reporter.Reporter.hide_keys")
+
+        @pytest.fixture
+        def mock_hide_request_headers_info(self, mocker):
+            return mocker.patch("scanapi.reporter.Reporter.hide_request_headers_info")
+
+        class TestWhenThereIsNoHideKeys:
+            def test_doesnt_call_hide_request_headers_info(
+                self,
+                reporter,
+                responses,
+                mock_hide_keys,
+                mock_hide_request_headers_info,
+            ):
+                mock_hide_keys.return_value = None
+                reporter.hide_headers_info(responses)
+                assert not mock_hide_request_headers_info.called
+
+        class TestWhenThereIsHideKey:
+            def test_calls_hide_request_headers_info(
+                self,
+                reporter,
+                responses,
+                mock_hide_keys,
+                mock_hide_request_headers_info,
+            ):
+                mock_hide_keys.return_value = ["Authorization"]
+                reporter.hide_headers_info(responses)
+                mock_hide_request_headers_info.assert_called_with(
+                    responses[0].request, ["Authorization"]
+                )
+
+    class TestHideRequestHeadersInfo:
+        class TestWhenThereIsNoHideSettings:
+            def test_doesnt_change_the_headers(self, reporter, req):
+                reporter.hide_request_headers_info(req, {})
+                assert req.headers["Authorization"] == "abc"
+
+        class TestWhenThereAreHideSettings:
+            def test_changes_the_sensitive_headers(self, reporter, req):
+                hide_settings = ["Authorization"]
+                reporter.hide_request_headers_info(req, hide_settings)
+                assert req.headers["Authorization"] == "<sensitive_information>"
+                assert req.headers["Token"] == "123"
+
+        class TestWhenThereAreMultipleHideSettings:
+            def test_changes_the_sensitive_headers(self, reporter, req):
+                hide_settings = ["Authorization", "Token"]
+                reporter.hide_request_headers_info(req, hide_settings)
+                assert req.headers["Authorization"] == "<sensitive_information>"
+                assert req.headers["Token"] == "<sensitive_information>"
+
+    class TestHideKeys:
+        class TestWhenThereIsNoReportSettings:
+            def test_returns_none(self, reporter):
+                if SETTINGS.get("report"):
+                    del SETTINGS["report"]
+
+                assert reporter.hide_keys() is None
+
+        class TestWhenThereReportSettingsIsEmpty:
+            def test_returns_none(self, reporter):
+                SETTINGS["report"] = {}
+
+                assert reporter.hide_keys() is None
+
+        class TestWhenThereIsNoHideSettings:
+            def test_returns_none(self, reporter):
+                SETTINGS["report"] = {"something": "else"}
+
+                assert reporter.hide_keys() is None
+
+        class TestWhenThereAreHideSettingsButNoHeaders:
+            def test_returns_none(self, reporter):
+                SETTINGS["report"]["hide"] = {"something": ["else"]}
+
+                assert reporter.hide_keys() is None
+
+        class TestWhenThereAreHideSettingsForNoHeaders:
+            def test_returns_none(self, reporter):
+                SETTINGS["report"]["hide"] = {"headers": ["Authorization"]}
+
+                assert reporter.hide_keys() == ["Authorization"]


### PR DESCRIPTION
Fix hiding sensitive info for headers, issue https://github.com/camilamaia/scanapi/issues/66.

## Description
After the refactor on the reporter templates, hide sensitive info from headers is not working. It shows the real data instead of `"<sensitive information>"`

## How to reproduce

Create a config file `.scanapi.yaml` with the content:
```
docs:
  hide:
    headers:
      - Authorization
```

Run scanapi with this config file and set an Authorization header inside the api specification:

```
api:
  base_url: ${BASE_URL}
  headers:
    Authorization: token123
```

The word `token123` will appear in the report, instead of `"<sensitive information>"`
