### PR TITLE
Fix report-example image not loading on PyPi

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ $ scanapi
 Then, the lib will hit the specified endpoints and generate a `scanapi-report.md` file with the report results
 
 <p align="center">
-  <img src="images/scanapi-report-example.png" width="700">
+  <img src="https://github.com/camilamaia/scanapi/blob/master/images/scanapi-report-example.png" width="700">
 </p>
 
 You can find a complete example of a demo project using ScanAPI at [scanapi-demo][scanapi-demo]!


### PR DESCRIPTION
## Description

At [PyPi page desccription](https://pypi.org/project/scanapi/0.0.15/) the image [scanapi-report-example.png](https://github.com/camilamaia/scanapi/blob/master/images/scanapi-report-example.png) is not loading

![image](https://user-images.githubusercontent.com/2728804/70911530-d71f8280-1ff0-11ea-8f56-85e65b4aec74.png)

This happens because it is being used the relative path to link the image on README.md

How it is now:
```
<p align="center">
  <img src="images/scanapi-report-example.png" width="700">
</p>
```

How it is should be:
```
<p align="center">
  <img src="https://github.com/camilamaia/scanapi/blob/master/images/scanapi-report-example.png" width="700">
</p>
```
closes https://github.com/camilamaia/scanapi/issues/78