### PR TITLE
Fix report-example image not loading on PyPi

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ $ scanapi
 Then, the lib will hit the specified endpoints and generate a `scanapi-report.md` file with the report results
 
 <p align="center">
-  <img src="https://github.com/camilamaia/scanapi/blob/master/images/scanapi-report-example.png" width="700">
+  <img src="https://raw.githubusercontent.com/camilamaia/scanapi/master/images/scanapi-report-example.png" width="700">
 </p>
 
 You can find a complete example of a demo project using ScanAPI at [scanapi-demo][scanapi-demo]!


### PR DESCRIPTION
## Description

PyPI is not loading README's image.

To fix it, I changed to use github image's raw link