### PR TITLE
Return body None when request has no body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Return params/headers None when request doesn't have params/headers #87
+
+### Fixed
+- Report-example image not loading on PyPi #86
 
 ## [0.0.17] - 2019-12-19
 ### Added

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,3 @@
 [pytest]
-addopts=-vvl
+addopts=-svvl
 bdd_features_base_dir = tests/functional/features/

--- a/scanapi/evaluators/code_evaluator.py
+++ b/scanapi/evaluators/code_evaluator.py
@@ -1,5 +1,6 @@
 import logging
 import re
+
 from types import SimpleNamespace
 
 from scanapi.errors import InvalidPythonCodeError

--- a/scanapi/reporter.py
+++ b/scanapi/reporter.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
-from jinja2 import Environment, PackageLoader, select_autoescape
 import logging
+
+from jinja2 import Environment, PackageLoader, select_autoescape
 
 from scanapi.settings import SETTINGS
 

--- a/scanapi/settings.py
+++ b/scanapi/settings.py
@@ -1,4 +1,5 @@
 import os
+
 from scanapi.yaml_loader import load_yaml
 
 SETTINGS_FILE = ".scanapi.yaml"

--- a/scanapi/tree/endpoint_node.py
+++ b/scanapi/tree/endpoint_node.py
@@ -29,6 +29,9 @@ class EndpointNode(APINode):
         if "headers" not in self.spec:
             return parent_headers
 
+        if not parent_headers:
+            parent_headers = {}
+
         return {**parent_headers, **self.spec_evaluator.evaluate(self.spec["headers"])}
 
     def define_params(self):
@@ -36,6 +39,9 @@ class EndpointNode(APINode):
 
         if "params" not in self.spec:
             return parent_params
+
+        if not parent_params:
+            parent_params = {}
 
         return {**parent_params, **self.spec_evaluator.evaluate(self.spec["params"])}
 

--- a/scanapi/tree/request_node.py
+++ b/scanapi/tree/request_node.py
@@ -22,7 +22,7 @@ class RequestNode(EndpointNode):
 
     def define_body(self):
         if "body" not in self.spec:
-            return {}
+            return
 
         return self.spec_evaluator.evaluate(self.spec["body"])
 

--- a/scanapi/tree/root_node.py
+++ b/scanapi/tree/root_node.py
@@ -17,13 +17,13 @@ class RootNode(APINode):
 
     def define_headers(self):
         if "headers" not in self.spec:
-            return {}
+            return
 
         return self.spec_evaluator.evaluate(self.spec["headers"])
 
     def define_params(self):
         if "params" not in self.spec:
-            return {}
+            return
 
         return self.spec_evaluator.evaluate(self.spec["params"])
 

--- a/tests/functional/step_defs/test_call_requests.py
+++ b/tests/functional/step_defs/test_call_requests.py
@@ -45,6 +45,6 @@ def get_called(api_spec, mock_request):
         "https://jsonplaceholder.typicode.com/todos",
         headers={},
         params={},
-        json={},
+        json=None,
         allow_redirects=False,
     )

--- a/tests/functional/step_defs/test_call_requests.py
+++ b/tests/functional/step_defs/test_call_requests.py
@@ -1,4 +1,5 @@
 import pytest
+
 from pytest_bdd import scenario, given, when, then
 
 from scanapi.tree.api_tree import APITree
@@ -43,8 +44,8 @@ def get_called(api_spec, mock_request):
     mock_request.assert_called_once_with(
         "GET",
         "https://jsonplaceholder.typicode.com/todos",
-        headers={},
-        params={},
+        headers=None,
+        params=None,
         json=None,
         allow_redirects=False,
     )

--- a/tests/unit/factories.py
+++ b/tests/unit/factories.py
@@ -4,6 +4,7 @@ from scanapi.reporter import Reporter
 from scanapi.requests_maker import RequestsMaker
 from scanapi.tree.api_node import APINode
 from scanapi.tree.api_tree import APITree
+from scanapi.tree.endpoint_node import EndpointNode
 from scanapi.yaml_loader import load_yaml
 
 
@@ -40,6 +41,11 @@ class APITreeFactory(factory.Factory):
             api_spec=WITHOUT_ENDPOINTS_MINIMAL_SPEC
         )
         method_not_allowed = factory.Trait(api_spec=METHOD_NOT_ALLOWED_SPEC)
+
+
+class EndpointNodeFactory(factory.Factory):
+    class Meta:
+        model = EndpointNode
 
 
 class RequestsMakerFactory(factory.Factory):

--- a/tests/unit/tree/test_api_tree.py
+++ b/tests/unit/tree/test_api_tree.py
@@ -34,7 +34,7 @@ class TestAPITree:
                 assert request.id == "posts_list_all_posts"
                 assert request.url == "https://jsonplaceholder.typicode.com/posts"
                 assert request.method == "get"
-                assert request.body == {}
+                assert request.body is None
                 assert request.headers == {}
 
             def test_build_endpoints_should_be_called(
@@ -66,7 +66,7 @@ class TestAPITree:
                 assert request.id == "list_all_posts"
                 assert request.url == "https://jsonplaceholder.typicode.com/posts"
                 assert request.method == "get"
-                assert request.body == {}
+                assert request.body is None
                 assert request.headers == {}
 
             def test_build_request_should_be_called(
@@ -96,7 +96,7 @@ class TestAPITree:
                 assert root_request.id == "docs"
                 assert root_request.url == "https://jsonplaceholder.typicode.com/docs"
                 assert root_request.method == "get"
-                assert root_request.body == {}
+                assert root_request.body is None
                 assert root_request.headers == {}
 
                 endpoint_request = api_tree.request_nodes[1]
@@ -109,7 +109,7 @@ class TestAPITree:
                     endpoint_request.url == "https://jsonplaceholder.typicode.com/posts"
                 )
                 assert endpoint_request.method == "get"
-                assert endpoint_request.body == {}
+                assert endpoint_request.body is None
                 assert endpoint_request.headers == {}
 
             def test_build_request_should_be_called(

--- a/tests/unit/tree/test_api_tree.py
+++ b/tests/unit/tree/test_api_tree.py
@@ -35,7 +35,7 @@ class TestAPITree:
                 assert request.url == "https://jsonplaceholder.typicode.com/posts"
                 assert request.method == "get"
                 assert request.body is None
-                assert request.headers == {}
+                assert request.headers is None
 
             def test_build_endpoints_should_be_called(
                 self, api_spec, mock_build_endpoints, mock_build_requests
@@ -67,7 +67,7 @@ class TestAPITree:
                 assert request.url == "https://jsonplaceholder.typicode.com/posts"
                 assert request.method == "get"
                 assert request.body is None
-                assert request.headers == {}
+                assert request.headers is None
 
             def test_build_request_should_be_called(
                 self, api_spec, mock_build_endpoints, mock_build_requests
@@ -97,7 +97,7 @@ class TestAPITree:
                 assert root_request.url == "https://jsonplaceholder.typicode.com/docs"
                 assert root_request.method == "get"
                 assert root_request.body is None
-                assert root_request.headers == {}
+                assert root_request.headers is None
 
                 endpoint_request = api_tree.request_nodes[1]
                 assert endpoint_request.spec == {
@@ -110,7 +110,7 @@ class TestAPITree:
                 )
                 assert endpoint_request.method == "get"
                 assert endpoint_request.body is None
-                assert endpoint_request.headers == {}
+                assert endpoint_request.headers is None
 
             def test_build_request_should_be_called(
                 self, api_spec, mock_build_endpoints, mock_build_requests

--- a/tests/unit/tree/test_endpoint_node.py
+++ b/tests/unit/tree/test_endpoint_node.py
@@ -1,5 +1,76 @@
 import pytest
+
 from scanapi.tree.endpoint_node import join_urls
+from tests.unit.factories import APITreeFactory
+
+
+class TestEndpointNode:
+    @pytest.fixture
+    def tree(self):
+        return APITreeFactory(with_endpoints_minimal=True)
+
+    @pytest.fixture
+    def root_node(self, tree):
+        return tree.root
+
+    @pytest.fixture
+    def endpoint_node(self, tree):
+        return tree.request_nodes[0].parent
+
+    class TestDefineUrl:
+        pass
+
+    class TestDefineHeaders:
+        class TestWhenParentHasNoHeaders:
+            def test_return_none(self, root_node, endpoint_node):
+                root_node.headers = None
+                assert endpoint_node.define_headers() is None
+
+        class TestWhenParentHasHeadersAndEndpointNodeDoesnt:
+            def test_return_parents_headers(self, root_node, endpoint_node):
+                parent_headers = {"parent_headers": "testing"}
+                root_node.headers = parent_headers
+                endpoint_node.headers = None
+                assert endpoint_node.define_headers() == parent_headers
+
+        class TestWhenParentAndEndpointNodeHaveHeaders:
+            def test_return_merged_headers(self, root_node, endpoint_node):
+                root_node.headers = {"parent_headers": "testing"}
+                endpoint_node.spec["headers"] = {"endpoint_node_headers": "testing"}
+
+                assert endpoint_node.define_headers() == {
+                    "parent_headers": "testing",
+                    "endpoint_node_headers": "testing",
+                }
+
+    class TestDefineParams:
+        class TestWhenParentHasNoParams:
+            def test_return_none(self, root_node, endpoint_node):
+                root_node.params = None
+                assert endpoint_node.define_params() is None
+
+        class TestWhenParentHasParamsAndEndpointNodeDoesnt:
+            def test_return_parents_params(self, root_node, endpoint_node):
+                parent_params = {"parent_params": "testing"}
+                root_node.params = parent_params
+                endpoint_node.params = None
+                assert endpoint_node.define_params() == parent_params
+
+        class TestWhenParentAndEndpointNodeHaveHeaders:
+            def test_return_merged_params(self, root_node, endpoint_node):
+                root_node.params = {"parent_params": "testing"}
+                endpoint_node.spec["params"] = {"endpoint_node_params": "testing"}
+
+                assert endpoint_node.define_params() == {
+                    "parent_params": "testing",
+                    "endpoint_node_params": "testing",
+                }
+
+    class TestDefineNamespace:
+        pass
+
+    class TestValidate:
+        pass
 
 
 class TestJoinUrls:


### PR DESCRIPTION
## Description

When creating requests without body It was setting body as  `{}` instead of None. The consequence of that is that it sends `content-length` as 2 in the headers, when it should not send `content-length` at all