### PR TITLE
Fix when custom var has upper case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Cases where custom var has upper case letters #99
 
 ## [0.0.18] - 2020-01-02
 ### Changed

--- a/scanapi/evaluators/string_evaluator.py
+++ b/scanapi/evaluators/string_evaluator.py
@@ -45,7 +45,7 @@ class StringEvaluator:
         for match in matches:
             variable_name = match.group("variable")
 
-            if variable_name.islower():
+            if any(letter.islower() for letter in variable_name):
                 continue
 
             try:

--- a/tests/unit/evaluators/test_string_evaluator.py
+++ b/tests/unit/evaluators/test_string_evaluator.py
@@ -21,7 +21,7 @@ class TestStringEvaluator:
 
     class TestEvaluateEnvVar:
         class TestWhenDoesNotMatchThePattern:
-            test_data = ["no env var", "${var}", "${{var}}", "${{VAR}}"]
+            test_data = ["no env var", "${var}", "${MyVar}", "${{var}}", "${{VAR}}"]
 
             @pytest.mark.parametrize("sequence", test_data)
             def test_should_return_sequence(self, string_evaluator, sequence):
@@ -106,12 +106,13 @@ class TestStringEvaluator:
                     class APITreeMock:
                         def __init__(self):
                             self.responses = {}
-                            self.custom_vars = {"user_id": "10"}
+                            self.custom_vars = {"user_id": "10", "apiKey": "abc123"}
 
                     return SpecEvaluator(APITreeMock())
 
                 test_data = [
                     ("${user_id}", "10"),
+                    ("${apiKey}", "abc123"),
                     ("something before ${user_id}", "something before 10"),
                     (
                         "something before ${user_id} something after",


### PR DESCRIPTION
## Description

Before, If we defined a var containing an upper case letter, like:
```yaml
vars:
    apiKey: abc123
```

and we tried to use it as `${apiKey}` it would raise the error:

```
ERROR:scanapi.evaluators.string_evaluator:'apiKey' environment variable not set or badly c
```

This PR fixes this problem. Fix #75